### PR TITLE
Enable edge-to-edge display in ListadoDocenteActivity

### DIFF
--- a/app/src/main/java/com/example/appclase6/ListadoDocenteActivity.kt
+++ b/app/src/main/java/com/example/appclase6/ListadoDocenteActivity.kt
@@ -3,7 +3,10 @@ package com.example.appclase6
 import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -20,7 +23,15 @@ class ListadoDocenteActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         setContentView(R.layout.listado_docente_main)
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            insets
+        }
+
+
 
         // Inicializar vistas
         rvDocentes = findViewById(R.id.rvDocentes)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,8 +8,8 @@
     tools:context=".MainActivity">
 
     <LinearLayout
-        android:layout_width="409dp"
-        android:layout_height="729dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="vertical"
         android:padding="15dp"
         tools:layout_editor_absoluteX="1dp"

--- a/app/src/main/res/layout/listado_docente_main.xml
+++ b/app/src/main/res/layout/listado_docente_main.xml
@@ -6,8 +6,8 @@
     android:layout_height="match_parent">
 
     <LinearLayout
-        android:layout_width="409dp"
-        android:layout_height="729dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="vertical"
         android:padding="15dp"
         tools:layout_editor_absoluteX="1dp"


### PR DESCRIPTION
This commit enables edge-to-edge display in `ListadoDocenteActivity` by calling `enableEdgeToEdge()` and applying window insets to handle system bars.

The layouts `activity_main.xml` and `listado_docente_main.xml` have been updated to use `match_parent` for width and `wrap_content` for height in their main LinearLayouts.